### PR TITLE
build: bump Go to 1.26.5 to address stdlib CVEs

### DIFF
--- a/.github/workflows/build_only.yml
+++ b/.github/workflows/build_only.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.4'
+          go-version: '1.26.5'
       - name: Get dependencies
         run: go get all
       - name: Run tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.4-alpine3.22 AS builder
+FROM golang:1.26.5-alpine3.24 AS builder
 ADD . /local_m3u8
 WORKDIR /local_m3u8
 ENV CGO_ENABLED=0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module ilteoood/local_m3u8
 
-go 1.25.4
+go 1.26.5
 
 require github.com/labstack/echo/v4 v4.15.4
 


### PR DESCRIPTION
## Summary

Bumps the Go toolchain from 1.25.4 to 1.26.5 (one of the releases that
addresses every stdlib CVE reported by the Anchore scan of the published
image). Also moves the builder base image to `-alpine3.24` to pick up the
latest Alpine security fixes. CI build workflow stays aligned.

## Changes

- `Dockerfile`: base image `golang:1.25.4-alpine3.22` -> `golang:1.26.5-alpine3.24`
- `go.mod`: `go 1.25.4` -> `go 1.26.5`
- `.github/workflows/build_only.yml`: `go-version: '1.25.4'` -> `'1.26.5'`

## Vulnerabilities addressed

The bump resolves every alert flagged against the Go stdlib
(`go1.25.4`) on the code-scanning dashboard, including the remaining
critical/high severity issues (e.g. `CVE-2026-27143`, `GO-2026-4337`,
`GO-2026-4918`, `CVE-2026-39822`, `GO-2026-4970`, `CVE-2026-27145`).

`golang.org/x/crypto`, `golang.org/x/net`, and `golang.org/x/sys` were
already upgraded to versions that clear their respective advisories in
the most recent dependabot PRs.

## Verification

- `go mod tidy` succeeds
- `go build ./...` succeeds
- `go vet ./...` is clean
- `go test ./...` passes (`internal`, `internal/env`, `internal/playlist`)

Refs: https://github.com/ilteoood/local_m3u8/security/code-scanning